### PR TITLE
Convert wiki docs to markdown/mkdocs and add github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,10 +57,11 @@ jobs:
       - name: Build MkDocs site
         run: mkdocs build --strict
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
         with:
-          path: ./site
+	  name: docs
+          path: build/docs
 
   # Deployment job
   deploy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,76 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches:
+      - main
+      - master
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install MkDocs and dependencies
+        run: |
+          pip install mkdocs-material mkdocs-minify-plugin
+
+      - name: Build MkDocs site
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./site
+
+  # Deployment job
+  deploy:
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-	  name: docs
+          name: docs
           path: build/docs
 
   # Deployment job

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs
-          path: build/docs
+          path: site
 
   # Deployment job
   deploy:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # PhysicalConstantsDictionary
 YAML dictionary of physical constants and tools to create consistent constant sets for Earth System Models
 
-To learn mode about this project, please read the available [documentation](https://github.com/ESCOMP/PhysicalConstantsDictionary/wiki). 
+To learn mode about this project, please read the available [documentation](https://ICAMS-US.github.io/PhysicalConstantsDictionary). 

--- a/docs/cpcd-parser.md
+++ b/docs/cpcd-parser.md
@@ -1,0 +1,160 @@
+# The CPCD Parser
+
+The Community Physical Constant Dictionary (CPCD) parser is a command-line tool that allow users to lookup physical constants in the YAML dictionary file and include them in their code by generating a suitable source file.
+
+## Requirements
+
+The CPCD parser requires:
+- The yaml-cpp library (version 0.6.2 or later), an open-source YAML parser and emitter written in C++ that supports [YAML version 1.2](https://yaml.org/spec/1.2/spec.html)
+- A C++ compiler supporting the C++11 standard
+
+## Installation
+
+At this time, the CPCD parser is distributed within the same repository as the Community Physical Constant Dictionary in the `tools/` directory, under a GNU General Public License ([GPL](https://www.gnu.org/licenses/gpl-3.0.en.html)).
+
+### Getting the Source Code
+
+The source code can be downloaded as follows:
+
+```bash
+git clone https://github.com/ESCOMP/PhysicalConstantsDictionary.git
+```
+
+### Installing yaml-cpp
+
+The yaml-cpp library uses CMake to support cross-platform building. A custom distribution for the yaml-cpp library (version 0.6.2) using the standard GNU build system is available [here](https://github.com/NESII/yaml-cpp/tree/gnu_autotools).
+
+To download and build yaml-cpp, follow these steps:
+
+```bash
+git clone -b gnu_autotools https://github.com/NESII/yaml-cpp.git
+cd yaml-cpp
+./configure --prefix=<your_yamlcpp_installation_path>
+make
+make install
+```
+
+### Building the CPCD parser
+
+The CPCD parser uses a standard GNU build system. To build this package on a given platform, the configure script needs to be run first:
+
+```bash
+./configure
+```
+
+This script will look for a suitable compiler (supporting C++11), then attempt to find the yaml-cpp library. The library's installation path can be provided to configure via:
+
+1. The `YAML_CPP` environment variable, set after loading the corresponding yaml-cpp module in common installations
+2. The `--with-yamlcpp` configure option, e.g.:
+
+```bash
+./configure --with-yamlcpp=/usr/local/yaml-cpp/0.6.2
+```
+
+The configure script also allows to set the installation path for the CPCP parser:
+
+```bash
+./configure --prefix=/usr/local/cpcd
+```
+
+A complete list of configure options can be obtained by typing:
+
+```bash
+./configure --help
+```
+
+Once configure completes successfully, the CPCD parser can be built by typing:
+
+```bash
+make
+```
+
+and installed as:
+
+```bash
+make install
+```
+
+The last step will install the `cpcd` executable under the `bin/` subdirectory of your installation path, e.g.: `/usr/local/cpcd/bin/cpcd`.
+
+## Running the CPCD parser
+
+The CPCD parser provides a command-line interface and can be driven through multiple options. A full list of options can be obtained by running `cpcd` with no options, or as `cpcd --help`:
+
+```bash
+$ ./src/cpcd --help
+Usage: cpcd [options] ...
+Main tool to validate, parse, and extract physical constant sets from the Community Physical Constant Dictionary
+
+Mandatory arguments to long options are mandatory for short options too.
+  -d, --dictionary YAML_FILE    Use YAML_FILE as dictionary
+  -r, --request YAML_FILE       Extract constants listed in YAML_FILE
+  -o, --output FILE             Save Fortran output to FILE
+  -x, --validate                Validate dictionary file before proceeding
+  -v, --verbose                 Use verbose output
+  -V, --version                 Print version information
+  -h, --help                    Display available options
+
+Exit status: 0 if successful, 1 if an error occurs.
+For bugs reporting, please visit: <https://github.com/ESCOMP/PhysicalConstantsDictionary>
+```
+
+### Request File Format
+
+A collection of physical constants to be extracted from the dictionary is provided to the CPCD parser also in a YAML file. A sample file (`req.yaml`) is distributed with this package in the `cpcd/test/` directory. Its content is included below:
+
+```yaml
+# This is an example of a user-requested list of physical constants
+# to be looked up in the dictionary by the CPCD parser and included
+# in the generated source code.
+
+ASHandbook1964: [ pi, gamma ]
+
+CODATA2014:
+  - standard_acceleration_of_gravity
+  - speed_of_light_in_vacuum
+  - stefan_boltzmann_constant
+
+GRS80: mean_radius
+
+IAPWS1995: [ liquid_water_triple_point_density, vapor_water_triple_point_density ]
+
+ASHandbook1964: square_root_of_2
+ASHandbook1964: pi
+```
+
+### Example Usage
+
+When the file above is provided to `cpcd` via option `-r`, the CPCD parser will output a source file that can be added to a model source code. Fortran is the only output language currently supported by the CPCD parser.
+
+The following command:
+
+```bash
+$ cpcd -d pcd.yaml -r req.yaml
+```
+
+will generate the Fortran module file `cpcd_mod.F90` in the current directory. This file will contain the extracted physical constants as Fortran parameters, declared by default as double precision:
+
+```fortran
+module cpcd
+  integer, parameter :: cpcd_kind = kind(1.d0)
+
+  ! - from set ASHandbook1964
+  real(cpcd_kind), parameter :: ASHandbook1964_pi = 3.141592653589793238462643_cpcd_kind
+  real(cpcd_kind), parameter :: ASHandbook1964_gamma = 0.577215664901532860606512_cpcd_kind
+  real(cpcd_kind), parameter :: ASHandbook1964_square_root_of_2 = 1.4142135623730950488_cpcd_kind
+
+  ! - from set CODATA2014
+  real(cpcd_kind), parameter :: CODATA2014_speed_of_light_in_vacuum = 299792458_cpcd_kind
+  real(cpcd_kind), parameter :: CODATA2014_standard_acceleration_of_gravity = 9.80665_cpcd_kind
+  real(cpcd_kind), parameter :: CODATA2014_stefan_boltzmann_constant = 5.67036713E-08_cpcd_kind
+
+  ! - from set GRS80
+  real(cpcd_kind), parameter :: GRS80_mean_radius = 6371008.7714_cpcd_kind
+
+  ! - from set IAPWS1995
+  real(cpcd_kind), parameter :: IAPWS1995_liquid_water_triple_point_density = 999.793_cpcd_kind
+  real(cpcd_kind), parameter :: IAPWS1995_vapor_water_triple_point_density = 0.00485458_cpcd_kind
+
+end module cpcd
+```

--- a/docs/dictionary-syntax.md
+++ b/docs/dictionary-syntax.md
@@ -1,0 +1,87 @@
+# Dictionary Syntax
+
+The Physical Constants Dictionary (PCD) is codified in [YAML 1.2](http://yaml.org/spec/1.2/spec.html).
+
+The content of such YAML file must comply with the current syntax rules:
+
+## Main Structure
+
+A PCD is a YAML node of kind [mappings](http://yaml.org/spec/1.2/spec.html), i.e. an unordered set of key: value node pairs, with the unique key name `physical_constants_dictionary`.
+
+```yaml
+physical_constants_dictionary:
+  # Dictionary content goes here
+```
+
+## Top-Level Fields
+
+The value associated to the `physical_constants_dictionary` key consists of the following YAML mapping nodes:
+
+### version_number (optional)
+The dictionary version, as in the standard GNU scheme: major.minor.revision
+
+### institution (optional)
+The name of the institution responsible for the dictionary
+
+### description (optional)
+A short description of the dictionary file
+
+### contact (optional)
+The email address of the designed POC for this file
+
+### set (mandatory)
+Internally consistent physical constants sets are included as YAML [block sequences](http://yaml.org/spec/1.2/spec.html) of mappings. A physical constant set is codified as a YAML mapping node, with the set name as the main key. Each set must begin with a hyphen (-), separated by space from the set name (key).
+
+## Physical Constants Sets
+
+The value associated to a set key includes the following mapping nodes:
+
+### description (mandatory)
+A brief description of the constants set
+
+### citation (mandatory)
+Literature references associated with the set
+
+### entries
+This node includes the actual dictionary entries for each physical constant included in the set. Entries are also organized as block sequences of mapping nodes, and must begin with a hyphen (-).
+
+## Physical Constant Entry Format
+
+A physical constant entry can be defined as shown in the example below:
+
+```yaml
+- name: standard_acceleration_of_gravity
+  value: 9.80665
+  units: m s-2
+  prec: double
+  type: strict
+  uncertainty: exact
+  description: |
+    Nominal acceleration of an object in a vacuum at sea level at a
+    geodetic latitude of 45 degrees.
+```
+
+## Entry Field Definitions
+
+The name of each key and its associated value are listed below:
+
+### name
+Physical constant's standard name
+
+### value
+Physical constant's numerical value
+
+### units
+Physical constant's units
+
+### prec
+`single` (4 bytes) or `double` (8 bytes) indicate the parameter's kind in Fortran
+
+### uncertainty (optional)
+The constant's absolute uncertainty (a number, or `exact`)
+
+### relative_uncertainty (optional)
+The constant's relative uncertainty (a number, or `exact`)
+
+### description
+A detailed description of the physical constant, with additional references if necessary.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Physical Constants Dictionary (PCD) Documentation
+
+This page provides up-to-date documentation of the features for the community-based Physical Constant Dictionary (PCD).
+
+Please contribute to it by opening an issue or pull request.
+
+Preliminary syntax rules for the YAML dictionary file are provided in [Dictionary Syntax](dictionary-syntax.md).
+
+An introductory guide to the CPCD parser is available in [The CPCD Parser](cpcd-parser.md).
+
+## Documentation Pages
+
+- [Dictionary Syntax](dictionary-syntax.md) - YAML syntax rules for the physical constants dictionary
+- [The CPCD Parser](cpcd-parser.md) - Guide to building and using the Community Physical Constant Dictionary parser

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,83 @@
+site_name: Physical Constants Dictionary (PCD)
+site_description: YAML dictionary of physical constants and tools to create consistent constant sets for Earth System Models
+site_author: ICAMS-US
+repo_url: https://github.com/ICAMS-US/PhysicalConstantsDictionary
+repo_name: ICAMS-US/PhysicalConstantsDictionary
+
+# Navigation structure
+nav:
+  - Home: index.md
+  - Dictionary Syntax: dictionary-syntax.md
+  - CPCD Parser: cpcd-parser.md
+
+# Theme configuration
+theme:
+  name: material
+  palette:
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: blue
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+
+# Documentation directory
+docs_dir: docs
+
+# Build directory
+site_dir: site
+
+# Markdown extensions
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+# Plugins
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+# Extra configuration
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ESCOMP/PhysicalConstantsDictionary
+  version:
+    provider: mike
+
+# Copyright
+copyright: Copyright &copy; ICAMS


### PR DESCRIPTION
Convert the wiki docs to markdown and add mkdocs.yml to convert to html.
Add a github action to create the html and publish to ICAMS-US.github.io